### PR TITLE
Use nesting for module names in docs

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -15,7 +15,8 @@ defmodule SurfaceBootstrap.MixProject do
       compilers: [:surface, :phoenix] ++ Mix.compilers(),
       deps: deps(),
       aliases: aliases(),
-      package: package()
+      package: package(),
+      docs: docs()
     ]
   end
 
@@ -61,6 +62,17 @@ defmodule SurfaceBootstrap.MixProject do
       files: ["lib", "mix.exs", "README*", "priv"],
       licenses: ["MIT"],
       links: %{"GitHub" => @source_url}
+    ]
+  end
+
+  defp docs() do
+    [
+      nest_modules_by_prefix: [
+        Surface.Components,
+        SurfaceBootstrap,
+        SurfaceBootstrap.Catalogue,
+        SurfaceBootstrap.Form
+      ]
     ]
   end
 end


### PR DESCRIPTION
I noticed many of the module names were cut off in the Hex docs:

<img width="393" alt="image" src="https://user-images.githubusercontent.com/336840/112235163-ce087100-8c89-11eb-8d68-6414af35d43b.png">

This PR applies some nesting to make it possible to see the module names:

<img width="346" alt="image" src="https://user-images.githubusercontent.com/336840/112235226-f1332080-8c89-11eb-8c57-cb25bd39353c.png">
