### PR TITLE
Use the newest bootstrap@5.0.0-beta3 version

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ To use Bootstraps's CSS styles, choose one of the following methods:
 Add the following line to your `layout_view.ex`:
 
 ```
-<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BmbxuPwQa2lc/FVzBcNJ7UAyJxM6wuqIj61tLrc4wSX0szH/Ev+nYRRuWlolflfl" crossorigin="anonymous">
+<link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" crossorigin="anonymous">
 ```
 
 Or download the `.css` file and manually add it to your `priv/static/css` folder.
@@ -118,7 +118,7 @@ Add `bootstrap` to the list of dependencies in `assets/package.json`:
 ```
 "dependencies": {
   ...
-  "bootstrap": "5.0.0-beta2"
+  "bootstrap": "5.0.0-beta3"
 }
 ```
 

--- a/priv/catalogue/catalogue.ex
+++ b/priv/catalogue/catalogue.ex
@@ -15,7 +15,7 @@ defmodule SurfaceBootstrap.Catalogue do
   def config() do
     [
       head_css: """
-      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta2/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-BmbxuPwQa2lc/FVzBcNJ7UAyJxM6wuqIj61tLrc4wSX0szH/Ev+nYRRuWlolflfl" crossorigin="anonymous">
+      <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.0-beta3/dist/css/bootstrap.min.css" rel="stylesheet" integrity="sha384-eOJMYsd53ii+scO/bJGFsiCZc+5NDVN2yr8+0RDqr0Ql0h+rP48ckxlpbzKgwra6" crossorigin="anonymous">
       <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.3.0/font/bootstrap-icons.css">
       <style>#{@app_css}</style>
       """,


### PR DESCRIPTION
Bootstrap 5.0.0-beta3 was released recently https://github.com/twbs/bootstrap/releases

This PR updates the docs and the version used in the Surface Catalogue from beta2 to beta3.