### PR TITLE
Alias phx.server as dev

### DIFF
--- a/mix.exs
+++ b/mix.exs
@@ -52,7 +52,8 @@ defmodule SurfaceBootstrap.MixProject do
 
   defp aliases do
     [
-      dev: "run --no-halt dev.exs"
+      dev: "run --no-halt dev.exs",
+      "phx.server": "dev"
       # format: ["format", "surface.format"]
     ]
   end


### PR DESCRIPTION
Adds an alias so you can do `mix phx.server` and everything appears to work as normal. Kinda a hack, but will possibly remove confusion. Without it, a new contributor might try and get

```elixir
** (ArgumentError) unknown application: :surface_bootstrap
    (elixir 1.12.0-rc.0) lib/application.ex:897: Application.app_dir/1
    (surface 0.3.2) lib/mix/tasks/compile/surface.ex:138: Mix.Tasks.Compile.Surface.app_modules/1
    (surface 0.3.2) lib/mix/tasks/compile/surface.ex:56: anonymous fn/2 in Mix.Tasks.Compile.Surface.get_colocated_assets/0
    (elixir 1.12.0-rc.0) lib/enum.ex:2358: Enum."-reduce/3-lists^foldl/2-0-"/3
    (surface 0.3.2) lib/mix/tasks/compile/surface.ex:14: Mix.Tasks.Compile.Surface.run/1
    (mix 1.12.0-rc.0) lib/mix/task.ex:394: anonymous fn/3 in Mix.Task.run_task/3
    (mix 1.12.0-rc.0) lib/mix/tasks/compile.all.ex:90: Mix.Tasks.Compile.All.run_compiler/2
    (mix 1.12.0-rc.0) lib/mix/tasks/compile.all.ex:70: Mix.Tasks.Compile.All.compile/4
```